### PR TITLE
change default output path to allure-results

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add the dependency to your Gemfile
 
 ## Advanced options
 
-You can specify the directory where the Allure test results will appear. By default it would be 'allure/data' within
+You can specify the directory where the Allure test results will appear. By default it would be 'gen/allure-results' within
 your current directory.
 
 ```ruby

--- a/lib/allure-ruby-adaptor-api.rb
+++ b/lib/allure-ruby-adaptor-api.rb
@@ -6,7 +6,7 @@ module AllureRubyAdaptorApi
     class << self
       attr_accessor :output_dir
 
-      DEFAULT_OUTPUT_DIR = 'allure/data'
+      DEFAULT_OUTPUT_DIR = 'gen/allure-results'
 
       def output_dir
         @output_dir || DEFAULT_OUTPUT_DIR


### PR DESCRIPTION
### Changes
- I've changed the default output path to `allure-results` from `allure/data` as report generation tools are searching for XML using the following Ant glob: ****/allure-results**
- This will fix this [issue](https://github.com/allure-framework/allure-cucumber/issues/4) as well
