### PR TITLE
Allow step title to differ from step name (if provided)

### DIFF
--- a/lib/allure-ruby-adaptor-api/builder.rb
+++ b/lib/allure-ruby-adaptor-api/builder.rb
@@ -62,11 +62,11 @@ module AllureRubyAdaptorApi
         end
       end
 
-      def start_step(suite, test, step)
+      def start_step(suite, test, step, title = step)
         MUTEX.synchronize do
           LOGGER.debug "Starting step #{suite}.#{test}.#{step}"
           self.suites[suite][:tests][test][:steps][step] = {
-              :title => step,
+              :title => title,
               :start => timestamp,
               :attachments => []
           }


### PR DESCRIPTION
To get around issues like #21, I propose that we allow users to set the step 'title' explicitly if they want. This means that I can create a step with a unique 'name', but a non-unique 'title'.

Eg Before:
```
start_step('suite', 'test', 'do a step of some sort')
stop_step('suite', 'test', 'do a step of some sort')
#Later in the test
start_step('suite', 'test', 'do a step of some sort')
stop_step('suite', 'test', 'do a step of some sort')
```
The first step is actually overwritten by the second step - since the suite, test and step name are the same; thus the hash entry is simply modified.

Instead, the below could be provided:

```
start_step('suite', 'test', 'some_unique_hash_1242343243234', 'do a step of some sort')
stop_step('suite', 'test', 'some_unique_hash_1242343243234', 'do a step of some sort')
#Later in the test
start_step('suite', 'test', 'some_unique_hash_2351427627434', 'do a step of some sort')
stop_step('suite', 'test', 'some_unique_hash_2351427627434', 'do a step of some sort')
```
This would create two unique steps - both would display with 'do a step of some sort' in the report.

This would obviously not fix the upstream libraries, but would likely give them an easier route to fixing the duplicated/merged step issues they're hitting. Since 'title' is set to 'step' if not provided, this will have no effect on current operation.