### PR TITLE
Use step_id in order to reduce duplicate steps in scenario when coming from allure-cucumber

### DIFF
--- a/lib/allure-ruby-adaptor-api/builder.rb
+++ b/lib/allure-ruby-adaptor-api/builder.rb
@@ -138,8 +138,8 @@ module AllureRubyAdaptorApi
                     xml.steps do
                       test[:steps].each do |step_title, step_obj|
                         xml.step(:start => step_obj[:start] || 0, :stop => step_obj[:stop] || 0, :status => step_obj[:status]) do
-                          xml.send :name, step_title
-                          xml.send :title, step_title
+                          xml.send :name, step_title.split("|")[0].strip # remove line numbers used for indexing in allure-cucumber
+                          xml.send :title, step_title.split("|")[0].strip # remove line numbers used for indexing in allure-cucumber
                           xml_attachments(xml, step_obj[:attachments])
                         end
                       end

--- a/lib/allure-ruby-adaptor-api/builder.rb
+++ b/lib/allure-ruby-adaptor-api/builder.rb
@@ -62,10 +62,10 @@ module AllureRubyAdaptorApi
         end
       end
 
-      def start_step(suite, test, step, step_line)
+      def start_step(suite, test, step, step_id)
         MUTEX.synchronize do
-          LOGGER.debug "Starting step #{suite}.#{test}.#{step}.#{step_line}"
-          self.suites[suite][:tests][test][:steps][step_line] = {
+          LOGGER.debug "Starting step #{suite}.#{test}.#{step}.#{step_id}"
+          self.suites[suite][:tests][test][:steps][step_id] = {
               :title => step,
               :start => timestamp,
               :attachments => []
@@ -101,12 +101,12 @@ module AllureRubyAdaptorApi
         end
       end
 
-      def stop_step(suite, test, step, step_line, status = :passed)
+      def stop_step(suite, test, step, step_id, status = :passed)
         MUTEX.synchronize do
-          LOGGER.debug "Stopping step #{suite}.#{test}.#{step}.#{step_line}"
-          self.suites[suite][:tests][test][:steps][step_line][:stop] = timestamp
-          self.suites[suite][:tests][test][:steps][step_line][:status] = status
-          self.suites[suite][:tests][test][:steps][step_line][:name] = name
+          LOGGER.debug "Stopping step #{suite}.#{test}.#{step}.#{step_id}"
+          self.suites[suite][:tests][test][:steps][step_id][:stop] = timestamp
+          self.suites[suite][:tests][test][:steps][step_id][:status] = status
+          self.suites[suite][:tests][test][:steps][step_id][:name] = name
         end
       end
 
@@ -137,10 +137,10 @@ module AllureRubyAdaptorApi
                       end
                     end
                     xml.steps do
-                      test[:steps].each do |step_line, step_obj|
+                      test[:steps].each do |step_id, step_obj|
                         xml.step(:start => step_obj[:start] || 0, :stop => step_obj[:stop] || 0, :status => step_obj[:status]) do
-                          xml.send :name, test[:steps][step_line][:title]
-                          xml.send :title, test[:steps][step_line][:title]
+                          xml.send :name, test[:steps][step_id][:title]
+                          xml.send :title, test[:steps][step_id][:title]
                           xml_attachments(xml, step_obj[:attachments])
                         end
                       end

--- a/lib/allure-ruby-adaptor-api/builder.rb
+++ b/lib/allure-ruby-adaptor-api/builder.rb
@@ -62,8 +62,7 @@ module AllureRubyAdaptorApi
         end
       end
 
-      def start_step(suite, test, step, step_id = '')
-        step_id = step if step_id == ''
+      def start_step(suite, test, step, step_id = step)
         MUTEX.synchronize do
           LOGGER.debug "Starting step #{suite}.#{test}.#{step}.#{step_id}"
           self.suites[suite][:tests][test][:steps][step_id] = {

--- a/lib/allure-ruby-adaptor-api/builder.rb
+++ b/lib/allure-ruby-adaptor-api/builder.rb
@@ -62,10 +62,10 @@ module AllureRubyAdaptorApi
         end
       end
 
-      def start_step(suite, test, step)
+      def start_step(suite, test, step, step_line)
         MUTEX.synchronize do
-          LOGGER.debug "Starting step #{suite}.#{test}.#{step}"
-          self.suites[suite][:tests][test][:steps][step] = {
+          LOGGER.debug "Starting step #{suite}.#{test}.#{step}.#{step_line}"
+          self.suites[suite][:tests][test][:steps][step_line] = {
               :title => step,
               :start => timestamp,
               :attachments => []
@@ -101,11 +101,12 @@ module AllureRubyAdaptorApi
         end
       end
 
-      def stop_step(suite, test, step, status = :passed)
+      def stop_step(suite, test, step, step_line, status = :passed)
         MUTEX.synchronize do
-          LOGGER.debug "Stopping step #{suite}.#{test}.#{step}"
-          self.suites[suite][:tests][test][:steps][step][:stop] = timestamp
-          self.suites[suite][:tests][test][:steps][step][:status] = status
+          LOGGER.debug "Stopping step #{suite}.#{test}.#{step}.#{step_line}"
+          self.suites[suite][:tests][test][:steps][step_line][:stop] = timestamp
+          self.suites[suite][:tests][test][:steps][step_line][:status] = status
+          self.suites[suite][:tests][test][:steps][step_line][:name] = name
         end
       end
 
@@ -136,10 +137,10 @@ module AllureRubyAdaptorApi
                       end
                     end
                     xml.steps do
-                      test[:steps].each do |step_title, step_obj|
+                      test[:steps].each do |step_line, step_obj|
                         xml.step(:start => step_obj[:start] || 0, :stop => step_obj[:stop] || 0, :status => step_obj[:status]) do
-                          xml.send :name, step_title.split("|")[0].strip # remove line numbers used for indexing in allure-cucumber
-                          xml.send :title, step_title.split("|")[0].strip # remove line numbers used for indexing in allure-cucumber
+                          xml.send :name, test[:steps][step_line][:title]
+                          xml.send :title, test[:steps][step_line][:title]
                           xml_attachments(xml, step_obj[:attachments])
                         end
                       end

--- a/lib/allure-ruby-adaptor-api/builder.rb
+++ b/lib/allure-ruby-adaptor-api/builder.rb
@@ -62,7 +62,8 @@ module AllureRubyAdaptorApi
         end
       end
 
-      def start_step(suite, test, step, step_id)
+      def start_step(suite, test, step, step_id = '')
+        step_id = step if step_id == ''
         MUTEX.synchronize do
           LOGGER.debug "Starting step #{suite}.#{test}.#{step}.#{step_id}"
           self.suites[suite][:tests][test][:steps][step_id] = {
@@ -101,7 +102,8 @@ module AllureRubyAdaptorApi
         end
       end
 
-      def stop_step(suite, test, step, step_id, status = :passed)
+      def stop_step(suite, test, step, step_id = '', status = :passed)
+        step_id = step if step_id == ''
         MUTEX.synchronize do
           LOGGER.debug "Stopping step #{suite}.#{test}.#{step}.#{step_id}"
           self.suites[suite][:tests][test][:steps][step_id][:stop] = timestamp

--- a/lib/allure-ruby-adaptor-api/version.rb
+++ b/lib/allure-ruby-adaptor-api/version.rb
@@ -1,6 +1,6 @@
 module AllureRubyAdaptorApi # :nodoc:
   module Version # :nodoc:
-    STRING = '0.7.0'
+    STRING = '0.7.1'
     ALLURE = '1.4.6'
   end
 end


### PR DESCRIPTION
## What does this do?
* Strips line numbers out that are adding using `allure-cucumber` in order to preserve the layout and display that the report usually has

## What does this fix?
* After adding line numbers in `allure-cucumber` to achieve indexing of duplicate steps, the line numbers were showing in generated reports

## Other Notes
Relates to https://github.com/allure-framework/allure-cucumber/pull/65