### PR TITLE
Fix allure error in JRuby

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    allure-ruby-adaptor-api (0.7.1)
+    allure-ruby-adaptor-api (0.7.3)
       mimemagic
       nokogiri (~> 1.7)
       uuid
@@ -13,11 +13,11 @@ GEM
       systemu (~> 2.6.2)
     mimemagic (0.3.2)
     mini_portile2 (2.3.0)
-    nokogiri (1.8.2)
+    nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
     rake (10.3.2)
     systemu (2.6.5)
-    uuid (2.3.8)
+    uuid (2.3.9)
       macaddr (~> 1.0)
 
 PLATFORMS
@@ -29,4 +29,4 @@ DEPENDENCIES
   rake
 
 BUNDLED WITH
-   1.13.7
+   1.16.5

--- a/lib/allure-ruby-adaptor-api/builder.rb
+++ b/lib/allure-ruby-adaptor-api/builder.rb
@@ -123,7 +123,7 @@ module AllureRubyAdaptorApi
         suites_xml = []
         (self.suites || []).each do |suite_title, suite|
           builder = Nokogiri::XML::Builder.new do |xml|
-            xml.send "ns2:test-suite", :start => suite[:start] || 0, :stop => suite[:stop] || 0, 'xmlns' => '', "xmlns:ns2" => "urn:model.allure.qatools.yandex.ru" do
+            xml['ns2'].send 'test-suite', :start => suite[:start] || 0, :stop => suite[:stop] || 0, 'xmlns' => '', 'xmlns:ns2' => 'urn:model.allure.qatools.yandex.ru' do
               xml.send :name, suite_title
               xml.send :title, suite_title
               xml.send "test-cases" do

--- a/lib/allure-ruby-adaptor-api/version.rb
+++ b/lib/allure-ruby-adaptor-api/version.rb
@@ -1,6 +1,6 @@
 module AllureRubyAdaptorApi # :nodoc:
   module Version # :nodoc:
-    STRING = '0.7.2'
+    STRING = '0.7.3'
     ALLURE = '1.4.6'
   end
 end


### PR DESCRIPTION
Addresses this [issue](https://github.com/allure-framework/allure-cucumber/issues/57), where Allure does not work in JRuby, which uses a stricter XML engine under the hood, as described here: https://bzzt.io/posts/how-to-fix-namespace_err-with-nokogirixmlbuilder-in-jruby

